### PR TITLE
Fix strapi client logging

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "set NODE_OPTIONS='--inspect'&&next dev",
+    "dev": "cross-env NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/client/src/lib/strapi/strapi-client.ts
+++ b/apps/client/src/lib/strapi/strapi-client.ts
@@ -12,7 +12,6 @@ export const strapiFetch = async <T = any>(
     },
     cache: 'no-store',
   });
-  console.log(authToken);
   // console.log(res);
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- update `dev` script to work cross-platform
- remove stray console log from `strapiFetch`

## Testing
- `npx eslint apps/client/src/lib/strapi/strapi-client.ts --config apps/client/eslint.config.js` *(fails: Cannot find package '@repo/eslint-config')*
- `npx tsc --noEmit` *(fails to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_68594d7591e88330a8765c57a7043693