### PR TITLE
Update activity log query

### DIFF
--- a/apps/client/src/lib/strapi/queries.ts
+++ b/apps/client/src/lib/strapi/queries.ts
@@ -26,6 +26,13 @@ export async function getTeamForUser(): Promise<TenantWithMembers | null> {
 }
 
 export async function getActivityLogs(): Promise<ActivityLog[]> {
+  const user = await getUser();
+  if (!user || !user.tenant) return [];
+  const tenantId = typeof user.tenant === 'object' ? user.tenant.id : user.tenant;
   const token = await getJwt();
-  return strapiFetch<ActivityLog[]>('/activity-logs', {}, token || undefined);
+  return strapiFetch<ActivityLog[]>(
+    `/tenant-activities?filters[tenant]=${tenantId}&sort=timestamp:desc`,
+    {},
+    token || undefined,
+  );
 }

--- a/apps/client/src/lib/strapi/types.ts
+++ b/apps/client/src/lib/strapi/types.ts
@@ -27,10 +27,11 @@ export interface TenantWithMembers extends Tenant {
 
 export interface ActivityLog {
   id: number;
-  action: string;
+  activity: ActivityType | string;
   timestamp: string | Date;
-  ipAddress?: string;
-  userName?: string;
+  user?: number | User;
+  tenant?: number | Tenant;
+  userRoles?: string;
 }
 
 export enum ActivityType {


### PR DESCRIPTION
## Summary
- fetch tenant activities instead of deprecated logs
- align `ActivityLog` interface with current CMS schema

## Testing
- `yarn lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685be97428e48330bbf216c6a9b33217