### PR TITLE
Add user details schema and settings save action

### DIFF
--- a/apps/client/src/components/dashboard/settings/actions.ts
+++ b/apps/client/src/components/dashboard/settings/actions.ts
@@ -1,0 +1,22 @@
+'use server';
+
+import { validatedActionWithUser } from '@/lib/auth/middleware';
+import { saveUserDetail } from '@/lib/strapi/api';
+import { z } from 'zod';
+
+const detailsSchema = z.object({
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  phone: z.string().optional(),
+  companyName: z.string().optional(),
+  taxNumber: z.string().optional(),
+  headquarters: z.string().optional(),
+});
+
+export const saveGeneralSettings = validatedActionWithUser(
+  detailsSchema,
+  async (data, _formData, user) => {
+    await saveUserDetail(user.id, data);
+    return { success: 'saved' };
+  },
+);

--- a/apps/client/src/components/dashboard/settings/general-settings.tsx
+++ b/apps/client/src/components/dashboard/settings/general-settings.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   Card,
   CardContent,
@@ -8,8 +10,15 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useActionState } from 'react';
+import { ActionState } from '@/lib/auth/middleware';
+import { saveGeneralSettings } from './actions';
 
 export function GeneralSettings() {
+  const [state, formAction, pending] = useActionState<ActionState, FormData>(
+    saveGeneralSettings,
+    {},
+  );
   return (
     <div className="space-y-6">
       <Card>
@@ -18,28 +27,23 @@ export function GeneralSettings() {
           <CardDescription>Frissítse személyes adatait</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="firstName">Keresztnév</Label>
-              <Input id="firstName" />
+          <form action={formAction} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="firstName">Keresztnév</Label>
+                <Input id="firstName" name="firstName" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="lastName">Vezetéknév</Label>
+                <Input id="lastName" name="lastName" />
+              </div>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="lastName">Vezetéknév</Label>
-              <Input id="lastName" />
+              <Label htmlFor="phone">Telefonszám</Label>
+              <Input id="phone" name="phone" type="tel" />
             </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="email">Email cím</Label>
-            <Input
-              id="email"
-              type="email"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="phone">Telefonszám</Label>
-            <Input id="phone" type="tel" defaultValue="+36 30 123 4567" />
-          </div>
-          <Button>Mentés</Button>
+            <Button type="submit" disabled={pending}>Mentés</Button>
+          </form>
         </CardContent>
       </Card>
 
@@ -49,19 +53,21 @@ export function GeneralSettings() {
           {/* <CardDescription>abc</CardDescription> */}
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="orgName">Cégnév</Label>
-            <Input id="orgName" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="orgTaxNumber">Adószám</Label>
-            <Input id="orgTaxNumber" />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="orgAddress">Székhely</Label>
-            <Input id="orgAddress" />
-          </div>
-          <Button>Mentés</Button>
+          <form action={formAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="companyName">Cégnév</Label>
+              <Input id="companyName" name="companyName" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="taxNumber">Adószám</Label>
+              <Input id="taxNumber" name="taxNumber" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="headquarters">Székhely</Label>
+              <Input id="headquarters" name="headquarters" />
+            </div>
+            <Button type="submit" disabled={pending}>Mentés</Button>
+          </form>
         </CardContent>
       </Card>
     </div>

--- a/apps/client/src/lib/strapi/api.ts
+++ b/apps/client/src/lib/strapi/api.ts
@@ -66,6 +66,29 @@ export async function fetchInvoices() {
   return strapiFetch<any>('/invoices', {}, token || undefined);
 }
 
+export async function saveUserDetail(
+  userId: number,
+  data: Record<string, any>,
+) {
+  const token = await getJwt();
+  const user = await strapiFetch<any>(
+    `/users/${userId}?populate=userDetail`,
+    {},
+    token || undefined,
+  );
+  const detailId = user.userDetail?.id;
+  if (detailId) {
+    return strapiFetch(`/user-details/${detailId}`, {
+      method: 'PUT',
+      body: JSON.stringify({ data }),
+    }, token || undefined);
+  }
+  return strapiFetch('/user-details', {
+    method: 'POST',
+    body: JSON.stringify({ data: { ...data, user: userId } }),
+  }, token || undefined);
+}
+
 export async function postActivity(
   activityType: ActivityType,
   activity: ActivityAction,

--- a/apps/client/src/lib/strapi/queries.ts
+++ b/apps/client/src/lib/strapi/queries.ts
@@ -6,7 +6,7 @@ export async function getUser(): Promise<IUser | null> {
   const token = await getJwt();
   if (!token) return null;
   try {
-    const u = await strapiFetch<IUser>('/users/me', {}, token);
+    const u = await strapiFetch<IUser>('/users/me?populate=userDetail', {}, token);
     return u;
   } catch (err) {
     return null;

--- a/apps/client/src/lib/strapi/types.ts
+++ b/apps/client/src/lib/strapi/types.ts
@@ -1,8 +1,19 @@
+export interface IUserDetail {
+  id: number;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  companyName?: string;
+  taxNumber?: string;
+  headquarters?: string;
+}
+
 export interface IUser {
   id: number;
   email: string;
   name?: string;
   tenant?: number | ITenant;
+  userDetail?: number | IUserDetail;
   [key: string]: any;
 }
 

--- a/apps/cms/src/api/user-detail/content-types/user-detail/schema.json
+++ b/apps/cms/src/api/user-detail/content-types/user-detail/schema.json
@@ -1,0 +1,27 @@
+{
+  "kind": "collectionType",
+  "collectionName": "user-detail",
+  "info": {
+    "singularName": "user-detail",
+    "pluralName": "user-details",
+    "displayName": "UserDetails",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "firstName": { "type": "string" },
+    "lastName": { "type": "string" },
+    "phone": { "type": "string" },
+    "companyName": { "type": "string" },
+    "taxNumber": { "type": "string" },
+    "headquarters": { "type": "string" },
+    "user": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "plugin::users-permissions.user",
+      "mappedBy": "userDetail"
+    }
+  }
+}

--- a/apps/cms/src/api/user-detail/controllers/user-detail.ts
+++ b/apps/cms/src/api/user-detail/controllers/user-detail.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/apps/cms/src/api/user-detail/routes/user-detail.ts
+++ b/apps/cms/src/api/user-detail/routes/user-detail.ts
@@ -1,0 +1,3 @@
+export default {
+  routes: [],
+};

--- a/apps/cms/src/api/user-detail/services/user-detail.ts
+++ b/apps/cms/src/api/user-detail/services/user-detail.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/apps/cms/src/extensions/users-permissions/content-types/user/schema.json
+++ b/apps/cms/src/extensions/users-permissions/content-types/user/schema.json
@@ -61,6 +61,12 @@
     "tenantRole": {
       "type": "enumeration",
       "enum": ["TenantAdmin", "TenantUser"]
+    },
+    "userDetail": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::user-detail.user-detail",
+      "inversedBy": "user"
     }
   }
 }

--- a/apps/cms/src/types/user-detail.interface.ts
+++ b/apps/cms/src/types/user-detail.interface.ts
@@ -1,0 +1,9 @@
+export interface UserDetail {
+  id: number;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  companyName?: string;
+  taxNumber?: string;
+  headquarters?: string;
+}

--- a/apps/cms/src/types/user-detail.ts
+++ b/apps/cms/src/types/user-detail.ts
@@ -1,0 +1,9 @@
+export interface UserDetail {
+  id: number;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  companyName?: string;
+  taxNumber?: string;
+  headquarters?: string;
+}

--- a/apps/cms/src/types/user.interface.ts
+++ b/apps/cms/src/types/user.interface.ts
@@ -1,4 +1,5 @@
 import { Tenant } from './tenant.interface';
+import { UserDetail } from './user-detail.interface';
 
 export type TenantRole = 'TenantAdmin' | 'TenantUser';
 
@@ -11,4 +12,5 @@ export interface User {
   provider: string;
   tenant?: Tenant;
   tenantRole?: TenantRole;
+  userDetail?: UserDetail;
 }

--- a/apps/cms/src/types/user.ts
+++ b/apps/cms/src/types/user.ts
@@ -1,4 +1,5 @@
 import { Tenant } from './tenant.interface';
+import { UserDetail } from './user-detail.interface';
 
 export type TenantRole = 'TenantAdmin' | 'TenantUser';
 
@@ -11,4 +12,5 @@ export interface User {
   provider: string;
   tenant?: Tenant;
   tenantRole?: TenantRole;
+  userDetail?: UserDetail;
 }


### PR DESCRIPTION
## Summary
- create `user-detail` Strapi collection type
- link `userDetail` relation to users
- add TypeScript interfaces for user details
- expose `saveUserDetail` client API helper
- create server action for saving general settings
- hook up save button and remove email field on the General Settings page
- fetch user including `userDetail`

## Testing
- `npx prettier -w apps/cms/src/api/user-detail/content-types/user-detail/schema.json` *(fails: Cannot find package 'prettier-config-custom')*
- `npx eslint apps/client/src/components/dashboard/settings/general-settings.tsx` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_6863d818a6048330af8002b8f650f453